### PR TITLE
add scss colors and mixin btns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8854,6 +8854,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -8884,14 +8892,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -1,3 +1,5 @@
+@import './_variables.scss';
+
 //---------------------------------------
 //				  Mixins
 //---------------------------------------
@@ -10,7 +12,7 @@
   }
 }
 
-/// Helper to clear inner floats
+/// Helper to clear inner float
 /// @author Nicolas Gallagher
 /// @link http://nicolasgallagher.com/micro-clearfix-hack/ Micro Clearfix
 @mixin clearfix {

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -20,7 +20,9 @@ COLORS
 */
 $theme-purple: #080A38;
 $light-purple: #71739B;
+$light-hover-purple: rgb(102, 104, 139);
 $theme-green: #15CF89;
+$theme-hover-green: rgb(25, 194, 129);
 
 $grey: #BBBBBB;
 $light-grey: #E6E6E6;
@@ -57,7 +59,7 @@ ADMIN PORTALS
 ADMIN BTNS
 ==========================
 */
-@mixin admin-voyage-btn($color) {
+@mixin admin-voyage-btn($color, $hover-color) {
 	background-color: $color;
 	color: white;
 	text-transform: uppercase;
@@ -65,6 +67,9 @@ ADMIN BTNS
 	font-size: 14px;
 	letter-spacing: 2px;
 	text-align: center;
+	&::hover {
+		background-color: $hover-color;
+	}
 }
   
 @mixin admin-voyage-btn--sub($color) {
@@ -74,6 +79,10 @@ ADMIN BTNS
 	padding: 5px;
 	font-size: 14px;
 	text-align: center;
+	&::hover {
+		background-color: color;
+		color: white;
+	}
 }
 /*
 ==========================

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -93,13 +93,23 @@ ADMIN BTNS
 }
 /*
 ==========================
-CARDS
+CARDS & TABS
 ==========================
 */
-@mixin cards {
+@mixin rounded-card {
 	border-radius: 20px;
 	background-color: white;
 	box-shadow: $drop-shadow;
+}
+@mixin half-rounded-tab($color) {
+	border-top-left-radius:  20px;
+	border-top-right-radius: 20px;
+	background-color: $color;
+	color: white;
+	text-align: center;
+	box-shadow: $drop-shadow;
+	font-size: 12px;
+	padding: 5px 10px;
 }
 /*
 ==========================

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -2,12 +2,96 @@
 //    Application-wide Variables
 //----------------------------------
 
-/// Regular font family
+/*
+==========================
+FONT
+==========================
+*/
 /// @type List
-$base-font-family: 'Raleway', sans-serif;
-$base-font-size: 16px;
+$base-font-family: 'Open Sans', 'Helvetica Neue', 'Raleway', sans-serif;
+$base-font-size: 14px;
+$portal-title-size: 40px;
+$portal-subcategory-size: 20px;
 $base-font-weight: 400;
+/*
+==========================
+COLORS
+==========================
+*/
+$theme-purple: #080A38;
+$light-purple: #71739B;
+$theme-green: #15CF89;
 
+$grey: #BBBBBB;
+$light-grey: #E6E6E6;
+$pale-grey: #EFEFEF;
+
+$health-green: #22B571;
+$health-yellow: #FFCC00;
+$health-red: #EF8585;
+/*
+==========================
+ADMIN PORTALS
+==========================
+*/
+@mixin admin-portal-title {
+	color: $light-grey;
+	font-size: $portal-title-size;
+	padding-top: 40px;
+	padding-bottom: 40px;
+	margin: 0 auto;
+	text-align: center;
+	display: block;
+	text-transform: uppercase;
+}
+
+@mixin admin-portal-subcategory {
+	color: $light-grey;
+	font-size: $portal-subcategory-size;
+	text-align: left;
+	text-transform: uppercase;
+	padding-bottom: 15px;
+}
+/*
+==========================
+ADMIN BTNS
+==========================
+*/
+@mixin admin-voyage-btn($color) {
+	background-color: $color;
+	color: white;
+	text-transform: uppercase;
+	padding: 10px;
+	font-size: 14px;
+	letter-spacing: 2px;
+	text-align: center;
+}
+  
+@mixin admin-voyage-btn--sub($color) {
+	background-color: white;
+	color: $color;
+	border: 1px solid $color;
+	padding: 5px;
+	font-size: 14px;
+	text-align: center;
+}
+/*
+==========================
+FORMS
+==========================
+*/
+@mixin form-label {
+	color: $light-grey;
+	text-transform: uppercase;
+	font-size: 12px;
+	text-align: left;
+}
+
+/*
+==========================
+ORIGINAL PROJECT VARIABLES
+==========================
+*/
 /// Color Map
 /// @type List
 $color-list: (

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -96,6 +96,16 @@ FORMS
 	text-align: left;
 }
 
+@mixin form-input {
+	border: 1px solid $light-grey;
+	padding: 5px;
+	color: $dark-grey;
+	font-size: 14px;
+	text-align: left;
+	margin-top: 5px;
+	margin-bottom: 5px;
+}
+
 /*
 ==========================
 ORIGINAL PROJECT VARIABLES

--- a/src/styles/abstracts/_variables.scss
+++ b/src/styles/abstracts/_variables.scss
@@ -33,6 +33,13 @@ $health-yellow: #FFCC00;
 $health-red: #EF8585;
 /*
 ==========================
+STYLING
+==========================
+*/
+$drop-shadow: 5px 5px 5px 10px $pale-grey;
+$border: 1px solid $light-grey;
+/*
+==========================
 ADMIN PORTALS
 ==========================
 */
@@ -83,6 +90,46 @@ ADMIN BTNS
 		background-color: color;
 		color: white;
 	}
+}
+/*
+==========================
+CARDS
+==========================
+*/
+@mixin cards {
+	border-radius: 20px;
+	background-color: white;
+	box-shadow: $drop-shadow;
+}
+/*
+==========================
+VOYAGE CARDS
+==========================
+*/
+@mixin voyage-card($color) {
+	width: 500px;
+	height: 300px;
+	border-radius: 20px;
+	background-color: $color;
+	color: $theme-purple;
+	box-shadow: $drop-shadow;
+}
+@mixin voyage-badge {
+	width: 186px;
+	height: 186px;
+	border-radius: 50%;
+	border: 15px solid $theme-purple;
+	color: $theme-purple;
+	background-color: white;
+}
+@mixin user-btn--apply {
+	background-color: $theme-green;
+	color: white;
+	text-transform: uppercase;
+	border-radius: 20px;
+	padding: 5px 10px;
+	letter-spacing: 2px;
+	text-align: center;
 }
 /*
 ==========================


### PR DESCRIPTION
Sass was already present in the original file, so I just added the project colors and a few button styling to the `src/styles/abstracts/_variables.scss` file
here are some mixins that are available thus far, and people should use when applicable:
- @include admin-portal-title
![image](https://user-images.githubusercontent.com/29721784/42790637-0021f0a4-8921-11e8-9b1e-106f37094b56.png)
- @include admin-portal-subcategory
![image](https://user-images.githubusercontent.com/29721784/42790642-0a2b2f0c-8921-11e8-9448-273e6a7d09d9.png)
- @include admin-voyage-btn($color, $hover-color)
![image](https://user-images.githubusercontent.com/29721784/42790653-1222da7a-8921-11e8-8d81-8a4d2f7bd971.png)
- @include admin-voyage-btn--sub($color)
![image](https://user-images.githubusercontent.com/29721784/42790655-1986aff8-8921-11e8-85d8-788868ec2125.png)
- @include form-label
![image](https://user-images.githubusercontent.com/29721784/42790659-2268d754-8921-11e8-872d-7a838912a2d2.png)
