### PR TITLE
Refactor/login and registration

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import VoyagePortal from './components/VoyagePortal';
 // TODO: remove after testing
 import DynamicForm from './components/DynamicForm';
 import Register from './components/Register';
+import Login from './components/Login';
 // TODO: remove after testing
 
 class App extends React.Component {
@@ -28,7 +29,10 @@ class App extends React.Component {
         <Header />
         <Switch>
           <Route exact path="/" component={Landing} />
-          <Route exact path="/login" component={Landing} />
+          {/* TODO: fix after testing */}
+          {/* <Route exact path="/login" component={Landing} /> */}
+    <Route exact path="/login" render={({ location: { search } }) => <Login queryString={search} />} />
+          {/* TODO: fix after testing */}
           <Route exact path="/register" component={Landing} />
           <Route exact path="/profile" component={UserProfile} />
           <Route exact path="/voyage" component={VoyagePortal} />
@@ -41,8 +45,8 @@ class App extends React.Component {
           <Route exact path="/companyfaq" render={() => <FAQ headerText="Company FAQs" data={companyFAQ} />} />
           <Route exact path="/programfaq" render={() => <FAQ headerText="Program FAQs" data={programFAQ} />} />
           {/* TODO: remove after testing */}
-          <Route exact path="/form" render={({ location: { search }}) => <DynamicForm purpose="chingu_application" queryString={search} /> } />
-          <Route exact path="/form/register" render={({ location: { search }}) => <Register queryString={search} />} />
+    <Route exact path="/form" render={({ location: { search }}) => <DynamicForm purpose="chingu_application" queryString={search} /> } />
+    <Route exact path="/form/register" render={({ location: { search }}) => <Register queryString={search} />} />
           {/* TODO: remove after testing */}
           <Route path="*" exact component={Missing404Page} />
         </Switch>

--- a/src/AppGlobalStore.js
+++ b/src/AppGlobalStore.js
@@ -5,7 +5,9 @@ const STORE_STATE_LOCAL_STORAGE_VERSION = 5;
 // https://d07c9835.ngrok.io/graphql
 // https://api.chingu.io/graphql
 const client = new ApolloClient({
-  uri: 'https://api.chingu.io/graphql',
+  // uri: 'https://api.chingu.io/graphql',
+  // TODO: remove after testing. we should use NODE_ENV switch
+  uri: 'http://localhost:8008/graphql',
   request: operation => operation.setContext({
     headers: {
       authorization: `Bearer ${localStorage.getItem('token')}`,
@@ -27,9 +29,6 @@ query getStateUser {
     interests
     coding_history
     country
-    skills {
-        name
-    }
     cohorts {
       id
       status
@@ -55,8 +54,7 @@ query getStateUser {
         start_date
         end_date
         status
-      }
-      
+      }  
     }
   }
 }

--- a/src/components/DynamicForm/index.jsx
+++ b/src/components/DynamicForm/index.jsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { DynamicFormMaker } from './DynamicFormMaker';
 import { Query, Mutation } from "react-apollo";
+import { Redirect } from "react-router-dom";
 import { gql } from "apollo-boost";
 import * as qs from "query-string";
 import './DynamicForm.css';
@@ -78,12 +79,11 @@ const DynamicFormSubmit = ({ onSubmit, variables }) => {
   return (
     <Mutation mutation={submitDynamicFormMutation}>
       {
-        (submitMutation, { loading, error }) => {
+        (submitMutation, { loading, error, data }) => {
           if (loading) return <Loader />;
-          if (error) { 
-            console.log(error); 
-            return <Error error={error.message} />;
-          };
+          if (error) return <Error error={error.message} />;
+          // TODO: option to pass a redirect path on submit?
+          if (data) return <Redirect to="/profile" />
           return (
             <button
               className="form-btn"
@@ -93,7 +93,9 @@ const DynamicFormSubmit = ({ onSubmit, variables }) => {
                 e.preventDefault();
                 onSubmit(submitMutation, variables);
               }}
-            >Submit</button>
+            >
+              Submit
+            </button>
           );
         }
       }

--- a/src/components/Error/Error.jsx
+++ b/src/components/Error/Error.jsx
@@ -10,8 +10,8 @@ class Error extends React.Component {
           <img alt="error" className="error-img" src={require('../../assets/error.png')} />
           <div className="error-message">{this.props.error}</div>
           <hr className="error-hline" />
-            <a className="error-go-back-btn" href={"/profile"} >
-              Go back
+          <a className="error-go-back-btn" href={this.props.goBack || "/profile"} >
+            Go back
           </a>
         </div>
       </div>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -4,6 +4,7 @@ import { graphql } from "react-apollo";
 import currentUserQuery from "../../queries/currentUserQuery";
 import Store from '../../AppGlobalStore';
 
+// TODO: refactor to Query link state
 const Header = props => {
   let teams = [];
   let user = null;
@@ -87,4 +88,4 @@ const Header = props => {
   )
 }
 
-export default graphql(currentUserQuery)(Header);
+export default Header;

--- a/src/components/Login/components/WithToken.jsx
+++ b/src/components/Login/components/WithToken.jsx
@@ -1,0 +1,67 @@
+import * as React from "react";
+import { Redirect } from "react-router-dom";
+import { Query } from "react-apollo";
+import { gql } from "apollo-boost";
+
+import Loading from "../../Loader/Loader";
+import Error from "../../Error/Error";
+
+const getAuthedUser = gql`
+    query getUserFromToken {
+      user {
+        id
+        avatar
+        username
+        status
+        background
+        interests
+        coding_history
+        country
+        cohorts {
+          id
+          status
+          start_date
+          end_date
+          members {
+            status
+            user {
+              username
+            }
+          }
+        }
+        teams {
+          id
+          title
+          standups {
+            progress_sentiment
+            expiration
+          }
+          cohort {
+            id
+            title
+            start_date
+            end_date
+            status
+          }  
+        }
+      }
+    }
+  `;
+
+const WithToken = () => (
+  <Query query={getAuthedUser}>
+  {
+    ({ data, loading, error }) => {
+      if (loading) return <Loading />;
+      if (error) return <Error error={error.message} />;
+      const { user } = data;
+      // TODO: write to link state once implemented
+      window.localStorage.setItem('store', JSON.stringify({ version: 5, user }));
+      // TODO: write to link state
+      return <Redirect to="/profile" />;
+    }
+  }
+  </Query> 
+);
+
+export default WithToken;

--- a/src/components/Login/components/WithoutToken.jsx
+++ b/src/components/Login/components/WithoutToken.jsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import { Redirect } from "react-router-dom";
+import { Mutation } from "react-apollo";
+import { gql } from "apollo-boost";
+import qs from "query-string";
+
+import Loading from "../../Loader/Loader";
+import Error from "../../Error/Error";
+
+// -- UTILITIES -- //
+const redirectSelector = ({ status }) => {
+  let path;
+  switch (status) {
+    case 'new_user':
+      path = '/form/register';
+      break;
+    case 'profile_incomplete':
+      path = '/profile/update';
+      break;
+    case 'profile_complete':
+      path = '/profile';
+      break;
+    default:
+      path = '/';
+      break;
+  }
+  return <Redirect to={path} />
+}
+
+const storeToken = (token) => window.localStorage.setItem('token', token);
+
+// -- MUTATION -- //
+const userAuthGithub = gql`
+  mutation authUser($code:String!) {
+    userAuthGithub(code:$code) {
+      user {
+        id
+        avatar
+        username
+        status
+        background
+        interests
+        coding_history
+        country
+        cohorts {
+          id
+          status
+          start_date
+          end_date
+          members {
+            status
+            user {
+              username
+            }
+          }
+        }
+        teams {
+          id
+          title
+          standups {
+            progress_sentiment
+            expiration
+          }
+          cohort {
+            id
+            title
+            start_date
+            end_date
+            status
+          }  
+        }
+      }
+      access_token
+    }  
+  }
+`;
+
+// -- COMPONENTS -- //
+// TODO: refactor styles
+const GithubLoginModal = ({ clientID }) => (
+  <React.Fragment>
+    <a className="login-container" href="/"></a>
+    <div className="login-box">
+      <div className="login-title">Github Authentication</div>
+      <a className="login-link" href={`https://github.com/login/oauth/authorize?client_id=${clientID}`}>
+        <button className="github-auth">
+          <img alt="github-icon" className="github-icon" src={'https://i.imgur.com/UBZgVgQ.png'} />
+          Log in with Github
+        </button>
+      </a>
+    </div>
+  </React.Fragment>
+);
+
+const WithoutToken = ({ queryString }) => (
+  <Mutation mutation={userAuthGithub}>
+    {
+      (authenticate, { data, error, loading }) => {
+        if (loading) return <Loading />;
+        if (error) return <Error error={error.message} goBack="/login" /> 
+        if (data) {
+          const { userAuthGithub: { user, access_token } } = data;
+          storeToken(access_token);
+          // TODO: write to link state when implemented
+          window.localStorage.setItem('store', JSON.stringify({ version: 5, user }));
+          // TODO: write to link state
+          return redirectSelector(user);
+        }
+        
+        if (queryString) {
+          const { code } = qs.parse(queryString);
+          authenticate({ variables: { code } });
+        }
+        return <GithubLoginModal clientID="e015fd9cc874fa5a34bf"/>
+      } 
+    }
+  </Mutation>
+);
+
+export default WithoutToken;

--- a/src/components/Login/components/index.js
+++ b/src/components/Login/components/index.js
@@ -1,0 +1,7 @@
+import WithToken from "./WithToken";
+import WithoutToken from "./WithoutToken";
+
+export {
+  WithToken,
+  WithoutToken,
+};

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,24 +1,108 @@
 import React from "react";
+import { Redirect } from "react-router-dom";
+import Error from "../Error/Error"; //TODO: replace Error.jsx -> index.jsx for simpler export
+import Loading from "../Loader/Loader";
+import { Mutation } from "react-apollo";
+import { gql } from "apollo-boost";
+import * as qs from "query-string";
 import './Login.css';
+
 // TODO: add state generator
 //   generate state and store in local storage
 //   on redirect confirm state match and remove
 
-const Login = () => (
+/**
+ * Component exists on:
+ *  - /login
+ *  - GitHub redirects to /login?code='' 
+ * 
+ * Goal
+ * - component to load displaying a LOGIN WITH GITHUB button
+ * - login -> redirects user to GitHub auth page
+ * - redirects back to Login component with 'code' qs param
+ * 
+ * - get code from url and initiate the userAuthGithub mutation
+ * - retrive user and access_token from response payload
+ * - store access_token in local storage
+ * - redirect based on user status field
+ *  - new_user -> Redirect to Register view
+ *  - profile_complete -> Redirect to User portal view
+ *  - [future] profile_incomplete -> Redirect to User update view
+*/
+
+// -- UTILITIES -- //
+const redirectSelector = ({ status }) => {
+  let path;
+  switch (status) {
+    case 'new_user':
+      path = '/form/register';
+      break;
+    case 'profile_incomplete':
+      path = '/profile/update';
+      break;
+    case 'profile_complete':
+      path = '/profile';
+      break;
+    default:
+      path = '/';
+      break;
+  }
+
+  return <Redirect to={path} />
+}
+
+const storeToken = (token) => window.localStorage.setItem('token', token);
+
+// -- COMPONENTS -- //
+// TODO: refactor styles
+const GithubLoginModal = ({ clientID }) => (
   <React.Fragment>
-    <a className="login-container" href="/">
-    </a>
+    <a className="login-container" href="/"></a>
     <div className="login-box">
       <div className="login-title">Github Authentication</div>
-      <a className="login-link" href={`https://github.com/login/oauth/authorize?client_id=e015fd9cc874fa5a34bf`}>
+      <a className="login-link" href={`https://github.com/login/oauth/authorize?client_id=${clientID}`}>
         <button className="github-auth">
           <img alt="github-icon" className="github-icon" src={'https://i.imgur.com/UBZgVgQ.png'} />
           Log in with Github
-    </button>
+        </button>
       </a>
     </div>
   </React.Fragment>
+);
 
+// -- MUTATION -- //
+const userAuthGithub = gql`
+  mutation authUser($code:String!) {
+    userAuthGithub(code:$code) {
+      user {
+        id
+        status
+      }
+      access_token
+    }
+  }
+`;
+
+const Login = ({ queryString }) => (
+  <Mutation mutation={userAuthGithub}>
+    {
+      (authenticate, { data, error, loading }) => {
+        if (loading) return <Loading />;
+        if (error) return <Error error={error.message} goBack="/login" /> 
+        if (data) {
+          const { userAuthGithub: { user, access_token } } = data;
+          storeToken(access_token);
+          return redirectSelector(user);
+        }
+        
+        if (queryString) {
+          const { code } = qs.parse(queryString);
+          authenticate({ variables: { code } });
+        }
+        return <GithubLoginModal clientID="e015fd9cc874fa5a34bf"/>
+      } 
+    }
+  </Mutation>
 );
 
 export default Login;

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,11 +1,6 @@
 import React from "react";
-import { Redirect } from "react-router-dom";
-import Error from "../Error/Error"; //TODO: replace Error.jsx -> index.jsx for simpler export
-import Loading from "../Loader/Loader";
-import { Mutation } from "react-apollo";
-import { gql } from "apollo-boost";
-import * as qs from "query-string";
 import './Login.css';
+import { WithToken, WithoutToken } from "./components";
 
 // TODO: add state generator
 //   generate state and store in local storage
@@ -30,79 +25,11 @@ import './Login.css';
  *  - [future] profile_incomplete -> Redirect to User update view
 */
 
-// -- UTILITIES -- //
-const redirectSelector = ({ status }) => {
-  let path;
-  switch (status) {
-    case 'new_user':
-      path = '/form/register';
-      break;
-    case 'profile_incomplete':
-      path = '/profile/update';
-      break;
-    case 'profile_complete':
-      path = '/profile';
-      break;
-    default:
-      path = '/';
-      break;
-  }
-
-  return <Redirect to={path} />
-}
-
-const storeToken = (token) => window.localStorage.setItem('token', token);
-
-// -- COMPONENTS -- //
-// TODO: refactor styles
-const GithubLoginModal = ({ clientID }) => (
-  <React.Fragment>
-    <a className="login-container" href="/"></a>
-    <div className="login-box">
-      <div className="login-title">Github Authentication</div>
-      <a className="login-link" href={`https://github.com/login/oauth/authorize?client_id=${clientID}`}>
-        <button className="github-auth">
-          <img alt="github-icon" className="github-icon" src={'https://i.imgur.com/UBZgVgQ.png'} />
-          Log in with Github
-        </button>
-      </a>
-    </div>
-  </React.Fragment>
-);
-
 // -- MUTATION -- //
-const userAuthGithub = gql`
-  mutation authUser($code:String!) {
-    userAuthGithub(code:$code) {
-      user {
-        id
-        status
-      }
-      access_token
-    }
-  }
-`;
-
 const Login = ({ queryString }) => (
-  <Mutation mutation={userAuthGithub}>
-    {
-      (authenticate, { data, error, loading }) => {
-        if (loading) return <Loading />;
-        if (error) return <Error error={error.message} goBack="/login" /> 
-        if (data) {
-          const { userAuthGithub: { user, access_token } } = data;
-          storeToken(access_token);
-          return redirectSelector(user);
-        }
-        
-        if (queryString) {
-          const { code } = qs.parse(queryString);
-          authenticate({ variables: { code } });
-        }
-        return <GithubLoginModal clientID="e015fd9cc874fa5a34bf"/>
-      } 
-    }
-  </Mutation>
+  window.localStorage.getItem('token') ?
+    <WithToken /> :
+    <WithoutToken queryString={queryString}/>
 );
 
 export default Login;

--- a/src/components/Register/index.jsx
+++ b/src/components/Register/index.jsx
@@ -1,18 +1,7 @@
-// TODO: refactor for dynamic forms
 import * as React from "react";
 import DynamicForm from "../DynamicForm";
 import './Register.css';
-// import { Redirect } from 'react-router-dom';
-// import { chinguApplicationData } from './chinguApplication.data';
-// import { renderQAs } from '../FormCreator/answerCreators';
-// import '../FormCreator/FormCreator.css';
-// import Error from '../Error/Error';
-// import Loader from '../Loader/Loader';
-// import Store from '../../AppGlobalStore';
-// import { REGISTER_USER, AUTH_MUTATION } from './graphql/mutations';
-// import SuccessForm from '../Success/Success';
-
-
+// TODO: refactor the styling
 const Register = ({ version, queryString }) => {
   // pattern for manually adding hidden field data (not found in url)
   // alternatively could have 'hidden' prop with object of fields
@@ -32,110 +21,5 @@ const Register = ({ version, queryString }) => {
     </div>
   );
 }
-
-// class Register extends React.Component {
-//   constructor(props) {
-//     super(props);
-
-//     this.state = {
-//       componentQueryingLoader: true,
-//       loading: false,
-//       error: false,
-//       errorMessage: '',
-//       success: false,
-//       redirectTarget: null,
-//       failedRegistration: false,
-//     }
-//   }
-
-//   componentDidMount = () => {
-//     if (!window.localStorage.getItem('token')) {
-//       Store.mutations.authUser(
-//         this.toggleLoading,
-//         this.errorHandling,
-//         { code: this.state.code },
-//         AUTH_MUTATION
-//       ).then(() => {
-//         if (Store.state.user && Store.state.user.status !== 'profile_incomplete') {
-//           this.setState({ redirectTarget: '/profile' })
-//         } else if (Store.state.user === null && window.localStorage.getItem("token")) {
-//           this.errorHandling(true);
-//         }
-//         this.setState({ componentQueryingLoader: false });
-//       })
-//     }
-//     else {
-//       Store.getAuthedUser()
-//       .then(() => {
-//         if (Store.state.user && Store.state.user.status !== 'profile_incomplete') {
-//           this.setState({ redirectTarget: '/profile' })
-//         } else if (Store.state.user === null && window.localStorage.getItem("token")) {
-//           this.errorHandling(true);
-//         }
-//         this.setState({ componentQueryingLoader: false });
-//       });
-//     }
-//   }
-
-//   toggleLoading = () => {
-//     this.setState({ loading: !this.state.loading })
-//   }
-
-
-//   onSubmit = () => {
-//     const user_data = {
-//       email: this.state[201],
-//       country: this.state[204],
-//       timezone: this.state[205]
-//     };
-
-//     const application_data = {
-//       exciting_about_chingu: this.state[202],
-//       value_of_chingu: this.state[203],
-//       chingu_referral: this.state[206]
-//     };
-
-//     Store.mutations.createUser(
-//       this.toggleLoading,
-//       this.errorHandling,
-//       { user_data, application_data },
-//       REGISTER_USER
-//     )
-//       .then(() => this.setState({ success: true }))
-//   }
-
-//   render() {
-//     if (this.state.componentQueryingLoader) return <Loader />;
-//     if (this.state.redirectTarget) {
-//       return (
-//         <Redirect
-//           push={true}
-//           from="/register"
-//           to={this.state.redirectTarget}
-//         />
-//       );
-//     }
-//     return (
-//       this.state.code
-//         ? <React.Fragment>
-//           {this.state.loading ? <Loader /> : null}
-//           {this.state.errorMessage !== "" ? <Error goBack={"/"} error={this.state.errorMessage} /> : null}
-//           <div className="chingu-application-container">
-//             <div className="chingu-application-modal">
-//               {this.state.success
-//                 ? <SuccessForm />
-//                 : <React.Fragment>
-//                   <div className="chingu-application-title">New User Onboarding Survey</div>
-//                   {renderQAs(chinguApplicationData, this.onFormChange, this.state)}
-//                   <button onClick={() => this.onSubmit()} className="chingu-application-btn">Save</button>
-//                 </React.Fragment>
-//               }
-//             </div>
-//           </div>
-//         </React.Fragment>
-//         : <Redirect to='/login' />
-//     )
-//   }
-// }
 
 export default Register;

--- a/src/components/UserProfile/UserSideBar.jsx
+++ b/src/components/UserProfile/UserSideBar.jsx
@@ -28,7 +28,9 @@ const USER_INFO_DOM_ELEMENTS = [
 
 class UserSideBar extends React.Component {
   render() {
-    const user = Store.state.user;
+    // const user = Store.state.user;
+    // TODO: Query link state when implemented
+    const { user } = JSON.parse(window.localStorage.getItem('store'));
 
     let userInfoDOM = USER_INFO_DOM_ELEMENTS.map(elem => {
       if (user[elem.schemaKey] && user[elem.schemaKey].length > 0) {

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -16,7 +16,9 @@ class UserProfile extends React.Component {
   }
 
   componentDidMount() {
-    let user = Store.getUserState();
+    // let user = Store.getUserState();
+    // TODO: Query link state when implemented
+    const { user } = JSON.parse(window.localStorage.getItem('store'));
     this.setState({ user: user }, () => {
       // let pendingApproval = user.cohorts.filter((cohort) => {
       //   let member = cohort.members.filter((member) => member.user.username === Store.state.user.username && member.status === 'pending_approval');


### PR DESCRIPTION
# Login Component path: `/login`
- uses `WithToken` component when token is in local storage
  - Queries for authed user -> updates LS -> redirects to /profile
- uses `WithoutToken` component when no token is available
  - render GithubLoginModal (initial load -> no code in qs)
  - click to initiate handshake
  - redirect back to /login
  - gets code from qs and calls `authenticate` mutation
  - on mutation response pass to redirectSelector function
  - redirects based on user.status field
    - `new_user` -> /register (fill out Chingu application dynamic form)
    - `profile_incomplete` -> /profile/update [future]
    - `profile_complete` -> /profile
