### PR TITLE
Fix infinite loader on errored public routes

### DIFF
--- a/src/components/utilities/Request.jsx
+++ b/src/components/utilities/Request.jsx
@@ -24,10 +24,9 @@ const Request = ({ component: Component, query, variables, options, globalLoader
   <Query query={query} variables={variables}>
     {
       ({ loading, error, data }) => {
-        globalLoader && toggleGlobalLoader(loading)
-
-        if (loading && globalLoader) return null
         if (error) return <Error error={error.message} /> // TODO: Pass goBack prop
+        globalLoader && toggleGlobalLoader(loading && globalLoader)
+        if (loading && globalLoader) return null
         return <Component {...props} data={data} />
       }
     }

--- a/src/components/utilities/Request.jsx
+++ b/src/components/utilities/Request.jsx
@@ -25,7 +25,7 @@ const Request = ({ component: Component, query, variables, options, globalLoader
     {
       ({ loading, error, data }) => {
         if (error) return <Error error={error.message} /> // TODO: Pass goBack prop
-        globalLoader && toggleGlobalLoader(loading && globalLoader)
+        globalLoader && toggleGlobalLoader(loading)
         if (loading && globalLoader) return null
         return <Component {...props} data={data} />
       }


### PR DESCRIPTION
Fix the error where global loader would spin indefinitely while trying to access public routes with queries which require auth headers. Without having one. Huh ^^