### PR TITLE
Medium custom loader

### DIFF
--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -27,12 +27,12 @@
 
 // -- MEIDUM -- //
 .loader-medium-container {
-  height: 100px; // TODO: remove
+  height: 180px; // TODO: remove
   width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: 500;
+  z-index: $z-middle;
 }
 
 .loader--medium {
@@ -43,6 +43,7 @@
   height: 3em;
   top: calc(100% - 1.5px);
   left: calc(100% - 1.5px);
+  z-index: $z-middle;
 }
 
 

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -1,22 +1,51 @@
 @import '../../styles/abstracts/_variables.scss';
 
+
+@mixin spinner {
+  border-radius: 50%;
+  animation: spin 2s linear infinite;
+  margin: 0 auto;
+  z-index: 1000;
+}
+
+// -- DEFAULT (LARGE)-- //
 .loader-container {
     @include transparent-background;
 }
+
 .loader {
-    border: 20px solid white;
-    border-top: 20px solid $theme-green;
-    border-radius: 50%;
-    width: 180px;
-    height: 180px;
-    animation: spin 2s linear infinite;
-    display: block;
-    margin: 0 auto;
-    top: calc(50vh - 90px);
-    position: absolute;
-    left: calc(50vw - 90px);
-    z-index: 1000;
+  @include spinner;
+  border: 20px solid white;
+  border-top: 20px solid $theme-green;
+  width: 180px;
+  height: 180px;
+  display: block;
+  top: calc(50vh - 90px);
+  position: absolute;
+  left: calc(50vw - 90px);
 }
+
+// -- MEIDUM -- //
+.loader-medium-container {
+  height: 100px; // TODO: remove
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 500;
+}
+
+.loader--medium {
+  @include spinner;
+  border: 5px solid white;
+  border-top: 5px solid $theme-green;
+  width: 3em;
+  height: 3em;
+  top: calc(100% - 1.5px);
+  left: calc(100% - 1.5px);
+}
+
+
 
 @keyframes spin {
     0% { transform: rotate(0deg); }

--- a/src/components/Loader/Loader.scss
+++ b/src/components/Loader/Loader.scss
@@ -27,12 +27,10 @@
 
 // -- MEIDUM -- //
 .loader-medium-container {
-  height: 180px; // TODO: remove
-  width: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
-  z-index: $z-middle;
+  z-index: $z-middle; // Hides blow header on scroll
 }
 
 .loader--medium {

--- a/src/components/Loader/index.jsx
+++ b/src/components/Loader/index.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from "prop-types"
 import './Loader.css';
 import Modal from "../common/Modal"
 import { Query } from "react-apollo"
@@ -12,12 +13,7 @@ const loaderQuery = gql`
   }
 `
 
-/**
- * Global Loader instance checks the isShowing flag in local store.loaderState
- * To toggle the flag usetoggleLoader utility in componenzs/utilities/toggleLoader and pass it the loading state from Queries/Mutations
- */
-
-export default ({ background }) => (
+const GlobalLoader = ({ background, style }) => (
   <Query query={loaderQuery}>
     {
       ({ data: { loaderState: { isShowing } } }) => {
@@ -28,3 +24,25 @@ export default ({ background }) => (
     }
   </Query>
 )
+
+
+const LoaderContainer = ({ background, style }) => {
+  console.log({ style })
+  if (style === "medium") {
+    return <div className="loader-medium-container"><div className="loader--medium" /></div>
+  }
+
+  else return <GlobalLoader background={background} />
+}
+
+LoaderContainer.propTypes = {
+  background: PropTypes.oneOf(["none", "transparent", ""]),
+  style: PropTypes.oneOf(["medium"])
+}
+
+LoaderContainer.proptypes = {
+  background: "",
+  style: ""
+}
+
+export default LoaderContainer

--- a/src/components/utilities/Request.jsx
+++ b/src/components/utilities/Request.jsx
@@ -27,7 +27,7 @@ const Request = ({ component: Component, query, variables, options, globalLoader
         if (error) return <Error error={error.message} /> // TODO: Pass goBack prop
         globalLoader && toggleGlobalLoader(loading)
         if (loading && globalLoader) return null
-        return <Component {...props} data={data} />
+        return <Component {...props} data={data} loading={loading} />
       }
     }
   </Query>


### PR DESCRIPTION
Added `style="medium"` prop option for custom Loader. 
Use for NewsFeed single component loaders with `<Loader style="medium"/>`


**Test**
![medloader](https://user-images.githubusercontent.com/6613473/44580828-bf890e80-a79b-11e8-988c-ae5b35d66e2f.gif)

**ISSUES**: Setting the height before content comes in.
Used `style={{ minHeight: "100px" }}` on parent div for the preview, but needs change.

closes #114 