### PR TITLE
Refactor/#205 project title mutation

### DIFF
--- a/src/components/ProjectShowcase/ProjectShowcase.scss
+++ b/src/components/ProjectShowcase/ProjectShowcase.scss
@@ -99,6 +99,7 @@ BUTTONS
   width: 100%;
 }
 
+
 /*
 ==========================
 OPEN IMAGE MODAL BTN
@@ -210,6 +211,11 @@ PROJECT INFO CONTAINER
 CARDS (PROJECT SIDEBAR)
 ==========================
 */
+.project-subcategory__title-container {
+  display: grid;
+  grid-template-areas: "title button"
+}
+
 .project-side-panel {
   grid-area: cards;
 }
@@ -287,6 +293,11 @@ PROJECT DESCRIPTION
 
 .project-portal__edit-button {
   @include system-button--sub($theme-green, $theme-green--lightest);
+  width: 150px;
+}
+.project-portal__edit-button--hidden {
+  @include system-button--sub($theme-green, $theme-green--lightest);
+  visibility: hidden;
   width: 150px;
 }
 
@@ -572,6 +583,8 @@ MEDIA QUERIES
   color: white;
   width: 150px;
 }
+
+
 
 
 // .project-portal__edit-form {

--- a/src/components/ProjectShowcase/ProjectShowcase.scss
+++ b/src/components/ProjectShowcase/ProjectShowcase.scss
@@ -287,7 +287,7 @@ PROJECT DESCRIPTION
 
 .project-portal__edit-button {
   @include system-button--sub($theme-green, $theme-green--lightest);
-  width: 120px;
+  width: 150px;
 }
 
 .project-portal__positioning-1  {
@@ -564,6 +564,13 @@ MEDIA QUERIES
     margin-left: calc(50% - 80px);
     margin-top: 20px;
   }
+}
+
+
+.project-portal__edit-button--error {
+  @include system-button($attention-red, $health-red);
+  color: white;
+  width: 150px;
 }
 
 

--- a/src/components/ProjectShowcase/components/Banner/index.jsx
+++ b/src/components/ProjectShowcase/components/Banner/index.jsx
@@ -21,12 +21,15 @@ class Banner extends React.Component {
   state = {
     isEditing: false,
     title: this.props.title,
-    elevator_pitch: this.props.elevator_pitch
+    elevator_pitch: this.props.elevator_pitch,
+    editBtnHidden: true
   };
 
   componentDidUpdate({ error }) {
     if (this.props.error && !error) this.setState({ isEditing: true })
   }
+
+  toggleEditable = editBtnHidden => this.setState({ editBtnHidden });
 
   toggleEditWithSave = () => {
     let { isEditing } = this.state;
@@ -70,13 +73,18 @@ class Banner extends React.Component {
   }
 
   render() {
-    console.log("component props", this.props);
-    const { isEditing, title, elevator_pitch } = this.state
+    const { isEditing, title, elevator_pitch, editBtnHidden } = this.state
     const { error, editable } = this.props;
-    const errorClass = error ? "--error" : ""
+
+    let btnState = ""
+    if (error) btnState = "--error"
+    else if (editBtnHidden) btnState = "--hidden"
 
     return (
-      <div className="project-portal__banner">
+      <div className="project-portal__banner"
+        onMouseEnter={() => editable && this.toggleEditable(false)}
+        onMouseLeave={() => editable && !isEditing && this.toggleEditable(true)}
+      >
         <div className="project-portal__banner--header">
           {isEditing ? (
             <React.Fragment>
@@ -104,7 +112,7 @@ class Banner extends React.Component {
         </div>
         {editable && (
           <button
-            className={`project-portal__edit-button${errorClass} project-portal__positioning-2`}
+            className={`project-portal__edit-button${btnState} project-portal__positioning-2`}
             onClick={() => this.toggleEditWithSave()}
           >
             <div className="project-portal__edit-button--text">

--- a/src/components/ProjectShowcase/components/Banner/index.jsx
+++ b/src/components/ProjectShowcase/components/Banner/index.jsx
@@ -63,7 +63,7 @@ class Banner extends React.Component {
   };
 
   editButtonText({ isEditing, error }) {
-    let lbl = "None"
+    let lbl = "Edit"
     if (isEditing) lbl = "Done"
     if (error) lbl = "Try again"
     return lbl
@@ -73,6 +73,7 @@ class Banner extends React.Component {
     console.log("component props", this.props);
     const { isEditing, title, elevator_pitch } = this.state
     const { error, editable } = this.props;
+    const errorClass = error ? "--error" : ""
 
     return (
       <div className="project-portal__banner">
@@ -103,14 +104,14 @@ class Banner extends React.Component {
         </div>
         {editable && (
           <button
-            className="project-portal__edit-button project-portal__positioning-2"
+            className={`project-portal__edit-button${errorClass} project-portal__positioning-2`}
             onClick={() => this.toggleEditWithSave()}
           >
             <div className="project-portal__edit-button--text">
-              <img
+              {!error && <img
                 className="project-portal__edit-button--img"
                 src={require('../../../../assets/edit-white.png')}
-                alt="edit" />
+                alt="edit" />}
               {this.editButtonText({ isEditing, error })}
             </div>
           </button>

--- a/src/components/ProjectShowcase/components/Banner/index.jsx
+++ b/src/components/ProjectShowcase/components/Banner/index.jsx
@@ -7,24 +7,21 @@ class Banner extends React.Component {
   static propTypes = {
     editable: PropTypes.bool,
     title: PropTypes.string,
-    elevatorPitch: PropTypes.string,
+    elevator_pitch: PropTypes.string,
     mutation: PropTypes.func
   };
 
   static defaultProps = {
     editable: false,
     title: "",
-    elevatorPitch: "",
+    elevator_pitch: "",
     mutation: console.log
   };
 
   state = {
     isEditing: false,
-    // error: null,
-    project_data: {
-      title: this.props.title,
-      elevator_pitch: this.props.elevatorPitch
-    },
+    title: this.props.title,
+    elevator_pitch: this.props.elevator_pitch
   };
 
   componentDidUpdate({ error }) {
@@ -44,23 +41,22 @@ class Banner extends React.Component {
   handleChange = e => {
     const { value, name } = e.target;
     this.setState({
-      project_data: {
-        [name]: value
-      }
+      [name]: value
     });
   };
 
   makeMutation = () => {
-    const { title } = this.state.project_data // TODOD: Add elevator_pitch
+    const { title, elevator_pitch } = this.state
     const { project_id, mutation } = this.props
     mutation({
-      variables: { project_id, project_data: { title } },
+      variables: { project_id, project_data: { title, elevator_pitch } },
       optimisticResponse: {
         __typename: "Mutation",
         projectUpdate: {
           __typename: "Project",
           id: project_id,
-          title
+          title,
+          elevator_pitch
         }
       }
     });
@@ -75,7 +71,7 @@ class Banner extends React.Component {
 
   render() {
     console.log("component props", this.props);
-    const { isEditing, project_data: { title, elevator_pitch } } = this.state
+    const { isEditing, title, elevator_pitch } = this.state
     const { error, editable } = this.props;
 
     return (
@@ -97,7 +93,7 @@ class Banner extends React.Component {
           {isEditing ? (
             <input
               className="project-portal__banner-edit"
-              name="elevatorPitch"
+              name="elevator_pitch"
               value={elevator_pitch}
               onChange={this.handleChange}
             />
@@ -134,6 +130,7 @@ function withMutation(Component) {
         project_data: $project_data) {
           id
           title
+          elevator_pitch
         }
       }
     `;
@@ -144,14 +141,14 @@ function withMutation(Component) {
         const title = data ? data.projectUpdate.title : props.title;
         const elevator_pitch = data
           ? data.projectUpdate.elevator_pitch
-          : props.elevatorPitch;
+          : props.elevator_pitch;
 
         return (
           <Component
             {...props}
             mutation={projectUpdate}
             title={title}
-            elevatorPitch={elevator_pitch}
+            elevator_pitch={elevator_pitch}
             error={!!error}
           />
         );

--- a/src/components/ProjectShowcase/graphql/getProjectAndUser.js
+++ b/src/components/ProjectShowcase/graphql/getProjectAndUser.js
@@ -6,16 +6,13 @@ const getProjectAndUser = gql`
       id
       title
       description
+      elevator_pitch
       project_url
       github_url
       users {
         id
         username
         avatar
-      }
-      skills {
-        id
-        name
       }
     }
   }

--- a/src/components/ProjectShowcase/index.jsx
+++ b/src/components/ProjectShowcase/index.jsx
@@ -61,6 +61,7 @@ class ProjectShowcase extends React.Component {
                         editable={user && this.isEditable(user, project)}
                         title={project.title}
                         elevatorPitch={project.elevatorPitch}
+                        project_id={this.props.projectId}
                       />
                       <HeroImage
                         editable={true}

--- a/src/components/ProjectShowcase/index.jsx
+++ b/src/components/ProjectShowcase/index.jsx
@@ -60,7 +60,7 @@ class ProjectShowcase extends React.Component {
                         editable={true}
                         editable={user && this.isEditable(user, project)}
                         title={project.title}
-                        elevatorPitch={project.elevatorPitch}
+                        elevator_pitch={project.elevator_pitch}
                         project_id={this.props.projectId}
                       />
                       <HeroImage


### PR DESCRIPTION
- Update mutation for title and elevator pitch editor
- Immediately update UI
![peek 2018-08-29 15-01](https://user-images.githubusercontent.com/6613473/44789306-86d2a600-ab9c-11e8-84f7-750b76864918.gif)
---
- On error, reopen editor and show red styled button with label "Try again"
- Made buttons a bit wider to fit the "Try again text"
![peek 2018-08-29 15-00](https://user-images.githubusercontent.com/6613473/44789311-89cd9680-ab9c-11e8-8f83-b6cc4f9d75cd.gif)

**Issues** 
- The error button color switches red/green because of :hover
- Once it errors, no way to cancel
