### PR TITLE
Hotfix/remove query string dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lodash": "^4.17.10",
     "node-sass-chokidar": "^1.3.0",
     "npm-run-all": "^4.1.3",
-    "query-string": "^6.1.0",
     "react": "^16.4.0",
     "react-apollo": "^2.1.9",
     "react-copy-to-clipboard": "^5.0.1",

--- a/src/components/DynamicForm/index.jsx
+++ b/src/components/DynamicForm/index.jsx
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Query } from "react-apollo";
-import qs from "query-string";
 
 import './DynamicForm.css';
 import Loader from '../Loader';
@@ -16,6 +15,25 @@ import {
 
 import dynamicFormQuery from "./dynamicFormQuery";
 import dynamicFormSubmitMutation from "./dynamicFormSubmitMutation";
+
+const parseParams = (queryString) => {
+  const queryParams = new URLSearchParams(window.location.search);
+  const params = {};
+  for(let entry of queryParams.entries()) {
+    if(entry.length) {
+      if(params[entry[0]]) {
+        if(Array.isArray(params[entry[0]])) {
+          params[entry[0]].push(...entry.slice(1));
+        } else {
+          params[entry[0]] = [params[entry[0]], ...entry.slice(1)];
+        }
+      } else {
+        params[entry[0]] = entry.slice(1).length === 1 ? entry[1] : entry.slice(1);
+      }
+    }
+  }
+  return params;
+}
 
 /**
  * @prop {string} purpose Dynamic Form purpose
@@ -55,7 +73,7 @@ const DynamicForm = (
               mutation={mutation}
               hiddenData={
                 queryString || hiddenData ?
-                  Object.assign(hiddenData, qs.parse(queryString)) :
+                  Object.assign(hiddenData, parseParams(queryString)) :
                   null
               }
               onValidate={onValidate}

--- a/src/components/DynamicForm/index.jsx
+++ b/src/components/DynamicForm/index.jsx
@@ -17,7 +17,7 @@ import dynamicFormQuery from "./dynamicFormQuery";
 import dynamicFormSubmitMutation from "./dynamicFormSubmitMutation";
 
 const parseParams = (queryString) => {
-  const queryParams = new URLSearchParams(window.location.search);
+  const queryParams = new URLSearchParams(queryString);
   const params = {};
   for(let entry of queryParams.entries()) {
     if(entry.length) {

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,6 +1,5 @@
 import React from "react"
 import { withRouter } from "react-router-dom"
-import qs from "query-string"
 import { gql } from "apollo-boost"
 // import AuthenticateWithGithub from "./components/GithubAuth";
 import { client } from "../../index"
@@ -27,7 +26,8 @@ class Login extends React.Component {
   async componentDidMount() {
     const { token, redirect } = localStorage
     const { queryString, history } = this.props
-    const { code } = qs.parse(queryString)
+    const queryParams = new URLSearchParams(queryString);
+    const code = queryParams.has('code') ? queryParams.get('code') : '';
 
     /**
      * IF token found or no code provided, redirect to /profile

--- a/yarn.lock
+++ b/yarn.lock
@@ -5974,13 +5974,6 @@ query-string@^4.1.0:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.1.0.tgz#01e7d69f6a0940dac67a937d6c6325647aa4532a"
-  dependencies:
-    decode-uri-component "^0.2.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6140,7 +6133,7 @@ react-router@^4.2.0:
     prop-types "^15.5.4"
     warning "^3.0.0"
 
-react-scripts@^1.1.4:
+react-scripts@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-1.1.5.tgz#3041610ab0826736b52197711a4c4e3756e97768"
   dependencies:
@@ -7060,10 +7053,6 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
-
 string-length@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
@@ -7662,6 +7651,10 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+validator@^10.7.0:
+  version "10.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-10.7.0.tgz#2d6443badcf942c86c19dc3deac7b87c0bd9b60d"
 
 value-equal@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
We were having issues with a specific dependency (`query-string`) that was preventing `yarn build` from running successfully. I have removed it and replaced it with the browser built in `URLSearchParam` API.

You can find more info regarding issue with dependency [here](https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/template/README.md#npm-run-build-fails-to-minify).